### PR TITLE
allow adding property to nested existing object

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function(content, sourceMap) {
 				if(previous.length === 0) {
 					imports.push("var " + expr + " = (" + current + " || {});");
 				} else if(index < names.length-1) {
-					imports.push(expr + " = {};");
+					imports.push(expr + " = expr || {};");
 				} else {
 					imports.push(expr + " = " + value + ";");
 				}


### PR DESCRIPTION
For example, when adding a jquery plugin and doing `imports-loader?jquery.event.drag`, `jquery.event` should not get set to `{}`