### PR TITLE
feat: add command separator for string syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Then you can inject the `jquery` value into the module by configuring the `impor
 
 ### Inline
 
+The `|` or `%20` (space) separate command parts.
+
+> ⚠ `%20` is space in a query string, because you can't use spaces in URLs
+
 **index.js**
 
 ```js
@@ -57,8 +61,8 @@ import myLib from 'imports-loader?imports=default%20jquery%20$!./example.js';
 ```
 
 ```js
-import myLib from 'imports-loader?imports[]=default%20jquery%20$&imports[]=angular!./example.js';
-// `%20` is space in a query string, equivalently `default jquery $` and `angular`
+import myLib from 'imports-loader?imports[]=default|jquery|$&imports[]=angular!./example.js';
+// `|` is separator in a query string, equivalently `default|jquery|$` and `angular`
 // Adds the following code to the beginning of example.js:
 //
 // import $ from "jquery";
@@ -66,8 +70,8 @@ import myLib from 'imports-loader?imports[]=default%20jquery%20$&imports[]=angul
 ```
 
 ```js
-import myLib from 'imports-loader?imports[]=named%20library%20myMethod&imports[]=angular!./example.js';
-// `%20` is space in a query string, equivalently `default jquery $` and `angular`
+import myLib from 'imports-loader?imports[]=named|library|myMethod&imports[]=angular!./example.js';
+// `|` is separator in a query string, equivalently `named|library|myMethod` and `angular`
 // Adds the following code to the beginning of example.js:
 //
 // import { myMethod } from "library";
@@ -75,8 +79,8 @@ import myLib from 'imports-loader?imports[]=named%20library%20myMethod&imports[]
 ```
 
 ```js
-const myLib = require(`imports-loader?type=commonjs&imports[]=single%20jquery%20$&imports[]=angular!./example.js`);
-// `%20` is space in a query string, equivalently `single jquery $` and `angular`
+const myLib = require(`imports-loader?type=commonjs&imports[]=single|jquery|$&imports[]=angular!./example.js`);
+// `|` is separator in a query string, equivalently `single|jquery|$` and `angular`
 // Adds the following code to the beginning of example.js:
 //
 // var $ = require("jquery");
@@ -84,8 +88,8 @@ const myLib = require(`imports-loader?type=commonjs&imports[]=single%20jquery%20
 ```
 
 ```js
-const myLib = require(`imports-loader?type=commonjs&imports=single%20myLib%20myMethod&&wrapper=window&!./example.js`);
-// `%20` is space in a query string, equivalently `single jquery $` and `angular`
+const myLib = require(`imports-loader?type=commonjs&imports=single|myLib|myMethod&&wrapper=window&!./example.js`);
+// `|` is separator in a query string, equivalently `single|myLib|myMethod` and `angular`
 // Adds the following code to the example.js:
 //
 // const myMethod = require('myLib');
@@ -242,9 +246,11 @@ Allows to use a string to describe an export.
 
 ##### `Syntax`
 
+The `" "` or `|` (space) separate command parts.
+
 String values let you specify import `syntax`, `moduleName`, `name` and `alias`.
 
-String syntax - `[[syntax] [moduleName] [name] [alias]]`, where:
+String syntax - `[[syntax] [moduleName] [name] [alias]]` or `[[syntax]|[moduleName]|[name]|[alias]]`, where:
 
 - `[syntax]`:
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,6 +13,23 @@ function sourceHasUseStrict(source) {
   return str.startsWith("'use strict'") || str.startsWith('"use strict"');
 }
 
+function splitCommand(command) {
+  const result = command
+    .split('|')
+    .map((item) => item.split(' '))
+    .reduce((acc, val) => acc.concat(val), []);
+
+  for (const item of result) {
+    if (!item) {
+      throw new Error(
+        `Invalid command "${item}" in "${command}" for imports. There must be only one separator: " ", or "|"`
+      );
+    }
+  }
+
+  return result;
+}
+
 function resolveImports(type, item) {
   const defaultSyntax = type === 'module' ? 'default' : 'single';
 
@@ -25,7 +42,7 @@ function resolveImports(type, item) {
       throw new Error(`Invalid "${item}" value for import`);
     }
 
-    const splittedItem = noWhitespaceItem.split(' ');
+    const splittedItem = splitCommand(noWhitespaceItem);
 
     if (splittedItem.length > 4) {
       throw new Error(`Invalid "${item}" value for import`);

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -214,6 +214,15 @@ Error: The \\"default\\" syntax does not support \\"lib_2_method_2_short\\" alia
 
 exports[`loader should throw an error when invalid arguments for imports: warnings 1`] = `Array []`;
 
+exports[`loader should throw an error when more then one command separator: errors 1`] = `
+Array [
+  "ModuleBuildError: Module build failed (from \`replaced original path\`):
+Error: Invalid command \\"\\" in \\"default | lib_1 default_name\\" for imports. There must be only one separator: \\" \\", or \\"|\\"",
+]
+`;
+
+exports[`loader should throw an error when more then one command separator: warnings 1`] = `Array []`;
+
 exports[`loader should throw an error when multiple duplicate of names found in "multiple" format: errors 1`] = `
 Array [
   "ModuleBuildError: Module build failed (from \`replaced original path\`):
@@ -235,7 +244,7 @@ exports[`loader should throw an error when no arguments for imports: warnings 1`
 exports[`loader should throw error on invalid inline syntax: errors 1`] = `
 Array [
   "ModuleBuildError: Module build failed (from \`replaced original path\`):
-Error: Invalid \\"named lib_2 name alias something\\" value for import",
+Error: Invalid \\"named|lib_2|name|alias|something\\" value for import",
 ]
 `;
 

--- a/test/fixtures/inline-broken.js
+++ b/test/fixtures/inline-broken.js
@@ -1,1 +1,1 @@
-require('../../src/cjs.js?imports=named%20lib_2%20name%20alias%20something!./some-library.js');
+require('../../src/cjs.js?imports=named|lib_2|name|alias|something!./some-library.js');

--- a/test/fixtures/inline2.js
+++ b/test/fixtures/inline2.js
@@ -1,1 +1,1 @@
-require('../../src/cjs.js?type=commonjs&imports[]=single%20lib_2%20lib_2_all&imports[]=multiple%20lib_2%20lib_2_method%20lib_2_method_alias!./some-library.js');
+require('../../src/cjs.js?type=commonjs&imports[]=single|lib_2|lib_2_all&imports[]=multiple|lib_2|lib_2_method|lib_2_method_alias!./some-library.js');

--- a/test/fixtures/inline3.js
+++ b/test/fixtures/inline3.js
@@ -1,2 +1,2 @@
-require('../../src/cjs.js?wrapper=window&imports=default%20lib_2%20$!./some-library.js');
+require('../../src/cjs.js?wrapper=window&imports=default%20lib_2|$!./some-library.js');
 

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -764,8 +764,8 @@ describe('loader', () => {
       type: 'module',
       imports: [
         'lib_1',
-        'default lib_1 default_name',
-        'default lib_1 $',
+        'default|lib_1 default_name',
+        'default|lib_1|$',
         'default lib_2 lib_2_all',
         'named lib_2 lib2_method_1',
         'named lib_2 lib2_method_2 lib_2_method_2_short',
@@ -1159,6 +1159,17 @@ describe('loader', () => {
         'multiple lib_3 toString',
         'multiple lib_3 toString',
       ],
+    });
+    const stats = await compile(compiler);
+
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+  });
+
+  it('should throw an error when more then one command separator', async () => {
+    const compiler = getCompiler('some-library.js', {
+      type: 'module',
+      imports: ['default | lib_1 default_name'],
     });
     const stats = await compile(compiler);
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

adds "|" as a command delimiter for string syntax

### Breaking Changes

No

### Additional Info

No

