### PR TITLE
chore(readme): remove redundant "to example.js"

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ import myLib from 'imports-loader?imports=default%20jquery%20$!./example.js';
 // `%20` is space in a query string, equivalently `default jquery $`
 // Adds the following code to the beginning of example.js:
 //
-// import $ from "jquery";` to `example.js
+// import $ from "jquery";
 ```
 
 ```js


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Improved docs.

### Breaking Changes

none

### Additional Info

The "inline" examples already say `// Adds the following code to the beginning of example.js:` in each block above the output added by `imports-loader`. This one ` to 'example.js` comment looks like it was left by accident.
