### PR TITLE
Adds documentation around using additionalCode for disabling AMD (addresses #83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,11 @@ import $ from 'jquery';
 Type: `String`
 Default: `undefined`
 
-Adds custom code.
+Adds custom code as a preamble before the module's code.
+
+##### Examples
+
+###### Define custom variable
 
 **webpack.config.js**
 
@@ -661,6 +665,46 @@ Generate output:
 import $ from 'jquery';
 
 var myVariable = false;
+
+// ...
+// Code
+// ...
+```
+
+###### Disable AMD Import Syntax
+
+**webpack.config.js**
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: require.resolve('example.js'),
+        use: [
+          {
+            loader: 'imports-loader',
+            options: {
+              imports: {
+                moduleName: 'jquery',
+                name: '$',
+              },
+              additionalCode: 'var define = false; /* Disable AMD for misbehaving libraries */',
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
+Generate output:
+
+```js
+import $ from 'jquery';
+
+var define = false; /* Disable AMD for misbehaving libraries */
 
 // ...
 // Code

--- a/README.md
+++ b/README.md
@@ -689,7 +689,8 @@ module.exports = {
                 moduleName: 'jquery',
                 name: '$',
               },
-              additionalCode: 'var define = false; /* Disable AMD for misbehaving libraries */',
+              additionalCode:
+                'var define = false; /* Disable AMD for misbehaving libraries */',
             },
           },
         ],


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This is meant to address the commentary in #83 around adding documentation for using the `additionalCode` option to disable AMD modules. It is only a documentation change in the README.md file.
 
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

This PR has no impact on the source code

### Additional Info
