### PR TITLE
feat: add custom parameter names for wrapper args

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,52 @@ import $ from 'jquery';
 }.call(window, myVariable, myOtherVariable));
 ```
 
+#### `Object` with different parameter names
+
+**webpack.config.js**
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: require.resolve('example.js'),
+        use: [
+          {
+            loader: 'imports-loader',
+            options: {
+              imports: {
+                moduleName: 'jquery',
+                name: '$',
+              },
+              wrapper: {
+                thisArg: 'window',
+                args: {
+                  myVariable: 'var1',
+                  myOtherVariable: 'var2',
+                },
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
+Generate output:
+
+```js
+import $ from 'jquery';
+
+(function (var1, var2) {
+  // ...
+  // Code
+  // ...
+}.call(window, myVariable, myOtherVariable));
+```
+
 ### `additionalCode`
 
 Type: `String`

--- a/src/index.js
+++ b/src/index.js
@@ -56,19 +56,29 @@ export default function loader(content, sourceMap) {
   if (typeof options.wrapper !== 'undefined') {
     let thisArg;
     let args;
+    let params;
 
     if (typeof options.wrapper === 'boolean') {
       thisArg = '';
+      params = '';
       args = '';
     } else if (typeof options.wrapper === 'string') {
       thisArg = options.wrapper;
+      params = '';
       args = '';
     } else {
       ({ thisArg, args } = options.wrapper);
-      args = args.join(', ');
+
+      if (Array.isArray(args)) {
+        params = '';
+        args = args.join(', ');
+      } else {
+        params = Object.keys(args).join(', ');
+        args = Object.values(args).join(', ');
+      }
     }
 
-    importsCode += `\n(function(${args}) {`;
+    importsCode += `\n(function(${params}) {`;
     codeAfterModule += `\n}.call(${thisArg}${args ? `, ${args}` : ''}));\n`;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -70,8 +70,8 @@ export default function loader(content, sourceMap) {
       ({ thisArg, args } = options.wrapper);
 
       if (Array.isArray(args)) {
-        params = '';
-        args = args.join(', ');
+        params = args.join(', ');
+        args = params;
       } else {
         params = Object.keys(args).join(', ');
         args = Object.values(args).join(', ');

--- a/src/options.json
+++ b/src/options.json
@@ -82,12 +82,20 @@
               "minLength": 1
             },
             "args": {
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "type": "string",
-                "minLength": 1
-              }
+              "anyOf": [
+                {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              ]
             }
           },
           "required": ["thisArg"]

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -1169,7 +1169,7 @@ exports[`loader should work with the "wrapper" options as an object notation: er
 exports[`loader should work with the "wrapper" options as an object notation: module 1`] = `
 "/*** IMPORTS FROM imports-loader ***/
 
-(function(myGlobalVariable, myOtherGlobalVariable) {
+(function() {
 var someCode = {
   number: 123,
   object: { existingSubProperty: 123 }
@@ -1180,3 +1180,20 @@ var someCode = {
 `;
 
 exports[`loader should work with the "wrapper" options as an object notation: warnings 1`] = `Array []`;
+
+exports[`loader should work with the "wrapper.args" options as an object notation: errors 1`] = `Array []`;
+
+exports[`loader should work with the "wrapper.args" options as an object notation: module 1`] = `
+"/*** IMPORTS FROM imports-loader ***/
+
+(function(foo1, foo2) {
+var someCode = {
+  number: 123,
+  object: { existingSubProperty: 123 }
+};
+
+}.call(window, bar1, bar2));
+"
+`;
+
+exports[`loader should work with the "wrapper.args" options as an object notation: warnings 1`] = `Array []`;

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -1169,7 +1169,7 @@ exports[`loader should work with the "wrapper" options as an object notation: er
 exports[`loader should work with the "wrapper" options as an object notation: module 1`] = `
 "/*** IMPORTS FROM imports-loader ***/
 
-(function() {
+(function(myGlobalVariable, myOtherGlobalVariable) {
 var someCode = {
   number: 123,
   object: { existingSubProperty: 123 }

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -264,8 +264,16 @@ exports[`validate options should throw an error on the "wrapper" option with "{"
 
 exports[`validate options should throw an error on the "wrapper" option with "{"thisArg":"window","args":true}" value 1`] = `
 "Invalid options object. Imports Loader has been initialized using an options object that does not match the API schema.
- - options.wrapper.args should be an array:
-   [non-empty string, ...] (should not have fewer than 1 item)"
+ - options.wrapper should be one of these:
+   boolean | non-empty string | object { thisArg, args? }
+   Details:
+    * options.wrapper.args should be one of these:
+      [non-empty string, ...] (should not have fewer than 1 item) | object { … }
+      Details:
+       * options.wrapper.args should be an array:
+         [non-empty string, ...] (should not have fewer than 1 item)
+       * options.wrapper.args should be an object:
+         object { … }"
 `;
 
 exports[`validate options should throw an error on the "wrapper" option with "{"thisArg":1}" value 1`] = `

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -259,6 +259,25 @@ describe('loader', () => {
     expect(getWarnings(stats)).toMatchSnapshot('warnings');
   });
 
+  it('should work with the "wrapper.args" options as an object notation', async () => {
+    const compiler = getCompiler('some-library.js', {
+      wrapper: {
+        thisArg: 'window',
+        args: {
+          foo1: 'bar1',
+          foo2: 'bar2',
+        },
+      },
+    });
+    const stats = await compile(compiler);
+
+    expect(getModuleSource('./some-library.js', stats)).toMatchSnapshot(
+      'module'
+    );
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+  });
+
   it('should work with the "additionalCode" option', async () => {
     const compiler = getCompiler('some-library.js', {
       additionalCode: 'var someVariable = 1;',

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -90,6 +90,7 @@ describe('validate options', () => {
         'window',
         { thisArg: 'window' },
         { thisArg: 'window', args: ['foo', 'bar'] },
+        { thisArg: 'window', args: { foo: 'bar' } },
       ],
       failure: [
         [],


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

I wanted to create a wrapper like this: https://github.com/google/shaka-player/blob/master/build/wrapper.template.js where it should be possible for me where arguments and parameters have different names.

The current loader is perfect for the use case: it has hook for `additionalCode` as well as `wrapper`. This PR adds the only missing functionality: differing names.

### Breaking Changes

None.

### Additional Info

None.
